### PR TITLE
Chore/Drop support for Ruby 2.7, 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v2
@@ -35,10 +35,6 @@ jobs:
 
   rspec_each:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v2
@@ -47,7 +43,7 @@ jobs:
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby-version }}
+        ruby-version: '3.1'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Setup RSpec configuration
       run: cp .rspec.example .rspec
@@ -64,7 +60,7 @@ jobs:
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '3.1'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Setup RuboCop configuration
       run: cp .rubocop.example .rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ gemspec
 gem 'byebug', '~> 11.1'
 gem 'rspec', '~> 3.12'
 gem 'rspec-sleeping_king_studios', '~> 2.7'
-gem 'rubocop', '~> 1.59'
+gem 'rubocop', '~> 1.64'
 gem 'rubocop-rake', '~> 0.6'
-gem 'rubocop-rspec', '~> 2.26', '>= 2.26.1'
+gem 'rubocop-rspec', '~> 3.0'
 gem 'simplecov', '~> 0.22'
 
 gem 'rake', '~> 13.1'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A library of utility services and concerns to expand the functionality of core c
 
 ## About
 
-SleepingKingStudios::Tools is tested against MRI Ruby 2.7 through 3.3.
+SleepingKingStudios::Tools is tested against MRI Ruby 3.1 through 3.3.
 
 ### Documentation
 


### PR DESCRIPTION
- Update RuboCop dependency.